### PR TITLE
fixing error when user have movies on watchlist and watchedlist and try to access the suggested page

### DIFF
--- a/app/services/suggested/index.rb
+++ b/app/services/suggested/index.rb
@@ -30,6 +30,8 @@ class Suggested::Index < BusinessProcess::Base
 
     return unless @movies.present?
 
+    @movies = @movies.flatten
+
     find_similar_movies
   end
 


### PR DESCRIPTION
Erro
  - Quando o usuário tinha filmes tanto na lista de filmes assistidos e filmes que ele quer assistir, ao acessar a página de filmes sugeridos, ocorria um erro.

O que foi mudado?
  - Coloquei um `.flatten` na variável antes de usar o `.each`, porque a lista de filmes que ele queria assistir estava em um array e a lista de filmes assistidos dentro desse array, mais ou menos assim `[..., ..., ..., [..., ..., ...,]]`, e o app quebrava quando tentava acessar os dados de dentro do array.